### PR TITLE
fix: cron schedule to once daily for Vercel free tier

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -14,7 +14,7 @@
   "crons": [
     {
       "path": "/api/cron/permit-sync",
-      "schedule": "0 */6 * * *"
+      "schedule": "0 0 * * *"
     }
   ]
 }


### PR DESCRIPTION
Changes `0 */6 * * *` to `0 0 * * *` (midnight UTC daily).