### PR TITLE
fix: anchor scroll position when opening permit details

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -994,6 +994,7 @@ export default function Home() {
                       setGeneratedLetter("");
                       setLetterError(null);
                       setEmailError(null);
+                      document.getElementById("permits")?.scrollIntoView({ behavior: "smooth", block: "start" });
                     }}
                   >
                     <div className="flex justify-between items-start mb-3">


### PR DESCRIPTION
When browsing permits and clicking a card, the view now scrolls to the top of the permit details section instead of staying at the user's scroll position. This improves UX by immediately showing the permit details without requiring the user to scroll up.