### PR TITLE
feat: anon quota gate, auth modal on limit, Ireland permit improvements

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -876,7 +876,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.19.0.tgz",
       "integrity": "sha512-QIcLGi508BAHkQ3pJNptsFz5WQMlpGbuBGBaIaXsWK8mel2kQ/rThYI+DbgjUvZrIr7MiuEuc9LcChJoEZK1xQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.12.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -636,7 +636,7 @@ function intFromEnv(name, fallback) {
 }
 
 const DEFAULT_QUOTA_LIMITS = {
-    freeDailyLetters: 15,
+    freeDailyLetters: 6,
     freeMonthlyLetters: 120,
     ngoDailyLetters: 200,
     ngoMonthlyLetters: 3000,
@@ -1787,9 +1787,11 @@ app.post('/api/generate-letter', optionalAuth, letterRateLimiter, async (req, re
         const quotaCheck = enforceQuota(req, 'generate_letter');
         if (!quotaCheck.allowed) {
             recordUsage(req, 'generate_letter', { outcome: 'blocked', reason: 'quota_limit' });
+            const isAnon = quotaCheck.status?.actor?.kind === 'anonymous';
             return res.status(429).json({
                 error: 'Daily or monthly letter generation limit reached.',
                 quota: quotaCheck.status?.usage || null,
+                requireLogin: isAnon,
             });
         }
     }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -556,6 +556,10 @@ export default function Home() {
       }, 35000);
       if (!res.ok) {
         const err = await res.json();
+        if (res.status === 429 && err.requireLogin) {
+          setIsAuthModalOpen(true);
+          return;
+        }
         throw new Error(err.error || "Failed to generate letter");
       }
       const data = await res.json();
@@ -1183,6 +1187,21 @@ export default function Home() {
                     <p className="mt-2 text-xs text-gray-500">
                       Remaining today: {lettersUsage.dailyRemaining ?? "unlimited"} · This month: {lettersUsage.monthlyRemaining ?? "unlimited"}
                     </p>
+                  )}
+                  {!isAuthenticated && lettersUsage?.dailyRemaining === 0 && (
+                    <div className="mt-3 p-4 rounded-xl bg-amber-500/10 border border-amber-500/30 flex flex-col gap-2">
+                      <p className="text-sm text-amber-300 font-medium">You&apos;ve used your 2 free letters for today.</p>
+                      <p className="text-xs text-gray-400">Sign in to get 6 letters per day and save your objections.</p>
+                      <button
+                        onClick={() => setIsAuthModalOpen(true)}
+                        className="mt-1 self-start px-4 py-2 bg-emerald-500 hover:bg-emerald-400 text-black text-sm font-semibold rounded-lg transition-all"
+                      >
+                        Sign in / Sign up
+                      </button>
+                    </div>
+                  )}
+                  {!isAuthenticated && lettersUsage?.dailyRemaining === 1 && (
+                    <p className="mt-2 text-xs text-amber-400">1 free letter remaining today — <button onClick={() => setIsAuthModalOpen(true)} className="underline hover:text-amber-300 transition-colors">sign in for 6/day</button></p>
                   )}
                   {letterError && (
                     <div className="mt-3 p-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">{letterError}</div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -994,6 +994,7 @@ export default function Home() {
                       setGeneratedLetter("");
                       setLetterError(null);
                       setEmailError(null);
+                      document.getElementById("permits")?.scrollIntoView({ behavior: "smooth", block: "start" });
                     }}
                   >
                     <div className="flex justify-between items-start mb-3">


### PR DESCRIPTION
## Summary
- Gate anonymous users at 2 letters/day; show sign-in modal when limit hit (instead of error)
- Amber CTA box + subtle nudge shown to anon users at/near daily limit
- Free (logged-in) tier reduced from 15 → 6 letters/day
- Backend 429 now includes `requireLogin: true` for anonymous callers
- Includes all prior `development` improvements: Ireland legal framework, permit display fixes, scroll anchor fix

## Test plan
- [ ] Anonymous user: generate 2 letters → 3rd attempt opens auth modal (not error text)
- [ ] Anon with 1 remaining: amber nudge inline text visible
- [ ] Anon at 0 remaining: amber CTA box with "Sign in / Sign up" button visible
- [ ] Logged-in free user: quota shows 6/day
- [ ] Letter generation returns fallback template (Gemini quota exhausted, expected)
- [ ] Ireland permits load and display correctly in permit browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)